### PR TITLE
Empty PepIDs now appear in MzTab

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/MzTab.h
+++ b/src/openms/include/OpenMS/FORMAT/MzTab.h
@@ -961,7 +961,8 @@ public:
         const String& filename,
         bool first_run_inference_only,
         std::map<std::pair<size_t,size_t>,size_t>& map_run_fileidx_2_msfileidx,
-        std::map<String, size_t>& idrun_2_run_index);
+        std::map<String, size_t>& idrun_2_run_index,
+        bool export_empty_pep_ids = false);
 
     /// Generate MzTab style list of PTMs from AASequence object. 
     /// All passed fixed modifications are not reported (as suggested by the standard for the PRT and PEP section).
@@ -980,11 +981,12 @@ public:
 		 * @return mzTab object 
 		 */
     static MzTab exportConsensusMapToMzTab(
-      const ConsensusMap & consensus_map, 
-      const String & filename,
+      const ConsensusMap& consensus_map,
+      const String& filename,
       const bool export_unidentified_features,
       const bool export_unassigned_ids,
       const bool export_subfeatures,
+      const bool export_empty_pep_ids = false,
       String title = "ConsensusMap export from OpenMS");
 
   protected:

--- a/src/openms/include/OpenMS/QC/TopNoverRT.h
+++ b/src/openms/include/OpenMS/QC/TopNoverRT.h
@@ -75,11 +75,12 @@ namespace OpenMS
              write meta values "ScanEventNumber" and "identified" in PeptideIdentification.
       @param exp Imported calibrated MzML file as MSExperiment
       @param features Imported featureXML file after FDR as FeatureMap
+      @return unassigned peptide identifications newly generated from unidentified MS2-Spectra
       @throws MissingInformation If exp is empty
       @throws IllegalArgument If retention time of the MzML and featureXML file does not match
       @throws IllegalArgument If a peptide identification does not have a corresponding MS2 scan
     **/
-    void compute(const MSExperiment& exp, FeatureMap& features);
+    std::vector<PeptideIdentification> compute(const MSExperiment& exp, FeatureMap& features);
 
     /// returns the name of the metric
     const String& getName() const override;
@@ -99,7 +100,7 @@ namespace OpenMS
     /// set ms2_included_ bool to true, if PeptideID exist and set "ScanEventNumber" for every PeptideID
     void setPresenceAndScanEventNumber_(PeptideIdentification& peptide_ID, const MSExperiment& exp);
 
-    /// add all unidentified MS2-Scans to unassignedPeptideIDs, the new unassignedPeptideIDs contains only Information about RT and "ScanEventNumber"
-    void addUnassignedPeptideIdentification_(const MSExperiment& exp, FeatureMap& features) ;
+    /// return all unidentified MS2-Scans as unassignedPeptideIDs, these contain only Information about RT and "ScanEventNumber"
+    std::vector<PeptideIdentification> getUnassignedPeptideIdentifications_(const MSExperiment& exp);
   };
 }

--- a/src/tests/class_tests/openms/source/TopNoverRT_test.cpp
+++ b/src/tests/class_tests/openms/source/TopNoverRT_test.cpp
@@ -144,7 +144,8 @@ START_SECTION(compute(const MSExperiment& exp, FeatureMap& features))
   exp.setSpectra(spectra);
 
   TopNoverRT top;
-  top.compute(exp, fmap);
+  vector<PeptideIdentification> new_unassigned_pep_ids;
+  new_unassigned_pep_ids = top.compute(exp, fmap);
 
   //test features
   TEST_EQUAL(fmap[0].getPeptideIdentifications()[0].getMetaValue("ScanEventNumber"), 1);
@@ -156,29 +157,29 @@ START_SECTION(compute(const MSExperiment& exp, FeatureMap& features))
   TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[0].getMetaValue("ScanEventNumber"), 2);
   TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[0].getMetaValue("identified"), 1);
   TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[1].getMetaValue("ScanEventNumber"), 3);
-  TEST_REAL_SIMILAR(fmap.getUnassignedPeptideIdentifications()[2].getRT(), 20);
-  TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[2].getMetaValue("ScanEventNumber"), 3);
-  TEST_EQUAL(fmap.getUnassignedPeptideIdentifications()[2].getMetaValue("identified"), 0);
-  TEST_REAL_SIMILAR(fmap.getUnassignedPeptideIdentifications()[2].getMZ(), 5.5);
+  TEST_REAL_SIMILAR(new_unassigned_pep_ids[0].getRT(), 20);
+  TEST_EQUAL(new_unassigned_pep_ids[0].getMetaValue("ScanEventNumber"), 3);
+  TEST_EQUAL(new_unassigned_pep_ids[0].getMetaValue("identified"), 0);
+  TEST_REAL_SIMILAR(new_unassigned_pep_ids[0].getMZ(), 5.5);
 
   //empty FeatureMap
   FeatureMap fmap_empty{};
-  top.compute(exp, fmap_empty);
-  TEST_EQUAL(fmap_empty.getUnassignedPeptideIdentifications().size(), 7);
+  new_unassigned_pep_ids = top.compute(exp, fmap_empty);
+  TEST_EQUAL(new_unassigned_pep_ids.size(), 7);
   //empty feature
   fmap_empty.clear();
   Feature feature_empty{};
   fmap_empty.push_back(feature_empty);
-  top.compute(exp, fmap_empty);
-  TEST_EQUAL(fmap_empty.getUnassignedPeptideIdentifications().size(), 7);
+  new_unassigned_pep_ids = top.compute(exp, fmap_empty);
+  TEST_EQUAL(new_unassigned_pep_ids.size(), 7);
   //empty PeptideIdentifications
   identifications.clear();
   fmap_empty.clear();
   feature_empty.setPeptideIdentifications(identifications);
   fmap_empty.setUnassignedPeptideIdentifications(identifications);
   fmap_empty.push_back(feature_empty);
-  top.compute(exp, fmap_empty);
-  TEST_EQUAL(fmap_empty.getUnassignedPeptideIdentifications().size(), 7);
+  new_unassigned_pep_ids = top.compute(exp, fmap_empty);
+  TEST_EQUAL(new_unassigned_pep_ids.size(), 7);
   //empty MSExperiment
   PeakMap exp_empty{};
   TEST_EXCEPTION_WITH_MESSAGE(Exception::MissingInformation, top.compute(exp_empty, fmap), "The mzml file / MSExperiment is empty.\n");

--- a/src/topp/QualityControl.cpp
+++ b/src/topp/QualityControl.cpp
@@ -171,6 +171,7 @@ protected:
     TopNoverRT qc_top_n_over_rt;
 
     // Loop through file lists
+    vector<PeptideIdentification> all_new_upep_ids;
     for (Size i = 0; i < number_exps; ++i)
     {
       //-------------------------------------------------------------
@@ -236,7 +237,10 @@ protected:
 
       if (isRunnable_(&qc_top_n_over_rt, status))
       {
-        qc_top_n_over_rt.compute(exp, fmap);
+        vector<PeptideIdentification> new_upep_ids = qc_top_n_over_rt.compute(exp, fmap);
+        // save the just calculated IDs
+        // this is needed like this, because appending the unassigned PepIDs directly to the ConsensusMap would destroy the mapping
+        all_new_upep_ids.insert(all_new_upep_ids.end(),new_upep_ids.begin(),new_upep_ids.end());
       }
 
       StringList out_feat = getStringList_("out_feat");
@@ -244,7 +248,7 @@ protected:
       {
         FeatureXMLFile().store(out_feat[i], fmap);
       }
-      //-------------------------------------------------------------
+      //------------------------------------------------------------- 
       // Annotate calculated meta values from FeatureMap to given ConsensusMap
       //-------------------------------------------------------------
 
@@ -261,6 +265,9 @@ protected:
     // mztab writer requires single PIs per CF
     IDConflictResolverAlgorithm::resolve(cmap);
 
+    // add calculated new unassigned PeptideIdentifications
+    cmap.getUnassignedPeptideIdentifications().insert(cmap.getUnassignedPeptideIdentifications().end(), all_new_upep_ids.begin(), all_new_upep_ids.end());
+
     //-------------------------------------------------------------
     // writing output
     //-------------------------------------------------------------
@@ -270,7 +277,7 @@ protected:
       ConsensusXMLFile().store(out_cm, cmap);
     }
 
-    MzTab mztab = MzTab::exportConsensusMapToMzTab(cmap, in_cm, true, true, true);
+    MzTab mztab = MzTab::exportConsensusMapToMzTab(cmap, in_cm, true, true, true, true);
 
     // Adding TIC information to meta data
     MzTabMetaData meta = mztab.getMetaData();


### PR DESCRIPTION
- MzTab-Export now has a bool "export_empty_pep_ids"

- TopNoverRT: compute now returns the calculated unidentified PepIDs, rather than append them to the FeatureMap

- TopNoverRT: changed the test accordingly

- QualityControl-TOPPTool uses these new features, so that there are now Rows in the PSM section for all empty PepIDs