### PR TITLE
Caching of validated CV terms in MzMLHandler, alternative to getAllChildTerms()

### DIFF
--- a/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
+++ b/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
@@ -166,8 +166,7 @@ public:
     {
       for (const auto& child : getTerm(parent).children)
       {
-        if (x(child)) return true;
-        else if (iterateAllChildren(child, x)) return true;
+        if (x(child) || iterateAllChildren(child, x)) return true;
       }
       return false;
     }

--- a/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
+++ b/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
@@ -172,7 +172,7 @@ public:
       return false;
     }
 
-    bool checkAndGetTermByName(const OpenMS::String& name, ControlledVocabulary::CVTerm& c) const;
+    const ControlledVocabulary::CVTerm* checkAndGetTermByName(const OpenMS::String& name) const;
 
     /**
         @brief Returns if @p child is a child of @p parent

--- a/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
+++ b/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
@@ -172,6 +172,11 @@ public:
       return false;
     }
 
+    /**
+        @brief Searches the existing terms for the given @p name
+
+        @return const Pointer to found term. When term is not found, returns nullptr
+    */
     const ControlledVocabulary::CVTerm* checkAndGetTermByName(const OpenMS::String& name) const;
 
     /**

--- a/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
+++ b/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
@@ -156,6 +156,7 @@ public:
     */
     void getAllChildTerms(std::set<String>& terms, const String& parent) const;
 
+    bool containsTermRecursively(const String& parent, const String& search) const;
     /**
         @brief Returns if @p child is a child of @p parent
 

--- a/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
+++ b/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
@@ -157,9 +157,11 @@ public:
     void getAllChildTerms(std::set<String>& terms, const String& parent) const;
 
     /**
-        @brief Iterates over all children of parent recurisively.
+        @brief Iterates over all children of parent recursively.
         @param x Function that gets the child-Strings passed. Must return bool.
                  Used for comparisons and / or to set captured variables.
+                 If the lambda return true, the iterating is exited prematurely.
+                 E.g. if you have found your search, you don't need to continue searching.
     */
     template <class LAMBDA>
     bool iterateAllChildren(const String& parent, LAMBDA x) const

--- a/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
+++ b/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
@@ -158,17 +158,19 @@ public:
 
     /**
         @brief Iterates over all children of parent recursively.
-        @param x Function that gets the child-Strings passed. Must return bool.
+        @param lbd Function that gets the child-Strings passed. Must return bool.
                  Used for comparisons and / or to set captured variables.
-                 If the lambda return true, the iterating is exited prematurely.
+                 If the lambda returns true, the iteration is exited prematurely.
                  E.g. if you have found your search, you don't need to continue searching.
+                 Otherwise, if you want to go through the whole tree (e.g. to fill a vector)
+                 you can just return false always to not quit early.
     */
     template <class LAMBDA>
-    bool iterateAllChildren(const String& parent, LAMBDA x) const
+    bool iterateAllChildren(const String& parent, LAMBDA lbd) const
     {
       for (const auto& child : getTerm(parent).children)
       {
-        if (x(child) || iterateAllChildren(child, x)) return true;
+        if (lbd(child) || iterateAllChildren(child, lbd)) return true;
       }
       return false;
     }

--- a/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
+++ b/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
@@ -157,11 +157,20 @@ public:
     void getAllChildTerms(std::set<String>& terms, const String& parent) const;
 
     /**
-        @brief Checks recursively if the given search term exists in the parent term
-
-        @exception Exception::InvalidValue is thrown if the term is not present
+        @brief Iterates over all children of parent recurisively.
+        @param x Function that gets the child-Strings passed. Must return bool.
+                 Used for comparisons and / or to set captured variables.
     */
-    bool containsTermRecursively(const String& parent, const String& search) const;
+    template <class LAMBDA>
+    bool iterateAllChildren(const String& parent, LAMBDA x) const
+    {
+      for (const auto& child : getTerm(parent).children)
+      {
+        if (x(child)) return true;
+        else if (iterateAllChildren(child, x)) return true;
+      }
+      return false;
+    }
 
     /**
         @brief Returns if @p child is a child of @p parent

--- a/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
+++ b/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
@@ -156,7 +156,13 @@ public:
     */
     void getAllChildTerms(std::set<String>& terms, const String& parent) const;
 
+    /**
+        @brief Checks recursively if the given search term exists in the parent term
+
+        @exception Exception::InvalidValue is thrown if the term is not present
+    */
     bool containsTermRecursively(const String& parent, const String& search) const;
+
     /**
         @brief Returns if @p child is a child of @p parent
 

--- a/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
+++ b/src/openms/include/OpenMS/FORMAT/ControlledVocabulary.h
@@ -172,6 +172,8 @@ public:
       return false;
     }
 
+    bool checkAndGetTermByName(const OpenMS::String& name, ControlledVocabulary::CVTerm& c) const;
+
     /**
         @brief Returns if @p child is a child of @p parent
 

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
@@ -369,7 +369,7 @@ protected:
                                       const Internal::MzMLValidator& validator);
 
       /// Writes user terms
-      void writeUserParam_(std::ostream& os, const MetaInfoInterface& meta, UInt indent, const String& path, const Internal::MzMLValidator& validator, const std::set<String>& exclude = {});
+      void writeUserParam_(std::ostream& os, const MetaInfoInterface& meta, UInt indent, const String& path, const Internal::MzMLValidator& validator, const std::set<String>& exclude = {}) const;
 
       /// Helper method that writes a software
       void writeSoftware_(std::ostream& os, const String& id, const Software& software, const Internal::MzMLValidator& validator);
@@ -390,7 +390,7 @@ protected:
       String writeCV_(const ControlledVocabulary::CVTerm& c, const DataValue& metaValue) const;
 
       /// Helper method to validate if the given CV is allowed in the current location (path)
-      bool validateCV_(const ControlledVocabulary::CVTerm& c, const String& path, const Internal::MzMLValidator& validator);
+      bool validateCV_(const ControlledVocabulary::CVTerm& c, const String& path, const Internal::MzMLValidator& validator) const;
 
       /// Helper method to look up a child CV term of @p parent_accession with the name @p name. If no such term is found, an empty term is returned.
       ControlledVocabulary::CVTerm getChildWithName_(const String& parent_accession, const String& name) const;
@@ -439,7 +439,7 @@ protected:
       /// The data processing list: id => Instrument
       Map<String, Instrument> instruments_;
       /// CV terms that have been checked in validateCV_()
-      Map<std::pair<String, String>, bool> cached_terms_;
+      mutable Map<std::pair<String, String>, bool> cached_terms_;
       /// The data processing list: id => Instrument
       Map<String, std::vector< DataProcessingPtr > > processing_;
       /// id of the default data processing (used when no processing is defined)

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
@@ -438,7 +438,7 @@ protected:
       Map<String, Software> software_;
       /// The data processing list: id => Instrument
       Map<String, Instrument> instruments_;
-      /// CV terms that have been checked in validateCV_()
+      /// CV terms-path-combinations that have been checked in validateCV_()
       mutable Map<std::pair<String, String>, bool> cached_terms_;
       /// The data processing list: id => Instrument
       Map<String, std::vector< DataProcessingPtr > > processing_;

--- a/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
+++ b/src/openms/include/OpenMS/FORMAT/HANDLERS/MzMLHandler.h
@@ -369,7 +369,7 @@ protected:
                                       const Internal::MzMLValidator& validator);
 
       /// Writes user terms
-      void writeUserParam_(std::ostream& os, const MetaInfoInterface& meta, UInt indent, const String& path, const Internal::MzMLValidator& validator, const std::set<String>& exclude = {}) const;
+      void writeUserParam_(std::ostream& os, const MetaInfoInterface& meta, UInt indent, const String& path, const Internal::MzMLValidator& validator, const std::set<String>& exclude = {});
 
       /// Helper method that writes a software
       void writeSoftware_(std::ostream& os, const String& id, const Software& software, const Internal::MzMLValidator& validator);
@@ -390,7 +390,7 @@ protected:
       String writeCV_(const ControlledVocabulary::CVTerm& c, const DataValue& metaValue) const;
 
       /// Helper method to validate if the given CV is allowed in the current location (path)
-      bool validateCV_(const ControlledVocabulary::CVTerm& c, const String& path, const Internal::MzMLValidator& validator) const;
+      bool validateCV_(const ControlledVocabulary::CVTerm& c, const String& path, const Internal::MzMLValidator& validator);
 
       /// Helper method to look up a child CV term of @p parent_accession with the name @p name. If no such term is found, an empty term is returned.
       ControlledVocabulary::CVTerm getChildWithName_(const String& parent_accession, const String& name) const;
@@ -438,6 +438,8 @@ protected:
       Map<String, Software> software_;
       /// The data processing list: id => Instrument
       Map<String, Instrument> instruments_;
+      /// CV terms that have been checked in validateCV_()
+      Map<std::pair<String, String>, bool> cached_terms_;
       /// The data processing list: id => Instrument
       Map<String, std::vector< DataProcessingPtr > > processing_;
       /// id of the default data processing (used when no processing is defined)

--- a/src/openms/source/ANALYSIS/ID/SiriusMSConverter.cpp
+++ b/src/openms/source/ANALYSIS/ID/SiriusMSConverter.cpp
@@ -477,7 +477,6 @@ namespace OpenMS
     ainfo.sf_type = spectra.getSourceFiles()[0].getFileType();
  
     // extract accession by name
-    //std::set<String> terms;
     ControlledVocabulary cv;
     cv.loadFromOBO("MS", File::find("/CV/psi-ms.obo"));
     auto lambda = [&ainfo, &cv] (const String& child)

--- a/src/openms/source/ANALYSIS/ID/SiriusMSConverter.cpp
+++ b/src/openms/source/ANALYSIS/ID/SiriusMSConverter.cpp
@@ -464,7 +464,7 @@ namespace OpenMS
 
     // create temporary input file (.ms)
     os.open(msfile.c_str());
-     if (!os)
+    if (!os)
     {
       throw Exception::UnableToCreateFile(__FILE__, __LINE__, OPENMS_PRETTY_FUNCTION, msfile);
     }
@@ -477,18 +477,21 @@ namespace OpenMS
     ainfo.sf_type = spectra.getSourceFiles()[0].getFileType();
  
     // extract accession by name
-    std::set<String> terms;
+    //std::set<String> terms;
     ControlledVocabulary cv;
     cv.loadFromOBO("MS", File::find("/CV/psi-ms.obo"));
-    cv.getAllChildTerms(terms, "MS:1000560");
-    for (std::set<String>::const_iterator it = terms.begin(); it != terms.end(); ++it)
+    auto lambda = [&ainfo, &cv] (const String& child)
     {
-      if (cv.getTerm(*it).name == ainfo.sf_type)
+      const ControlledVocabulary::CVTerm& c = cv.getTerm(child);
+      if (c.name == ainfo.sf_type)
       {
-          cv.getTerm(*it);
-          ainfo.sf_accession = cv.getTerm(*it).id;
+        ainfo.sf_accession = c.id;
+        return true;
       }
-    }  
+      return false;
+    };
+    cv.iterateAllChildren("MS:1000560", lambda);
+
     // native_id
     ainfo.native_id_accession = spectra.getSourceFiles()[0].getNativeIDTypeAccession();
     ainfo.native_id_type = spectra.getSourceFiles()[0].getNativeIDType();

--- a/src/openms/source/FORMAT/ControlledVocabulary.cpp
+++ b/src/openms/source/FORMAT/ControlledVocabulary.cpp
@@ -458,7 +458,6 @@ namespace OpenMS
     return terms_;
   }
 
-#if 1
   bool ControlledVocabulary::containsTermRecursively(const String& parent, const String& search) const
   {
     for (const auto& it : getTerm(parent).children)
@@ -468,7 +467,6 @@ namespace OpenMS
     }
     return false;
   }
-#endif
 
   void ControlledVocabulary::getAllChildTerms(set<String>& terms, const String& parent) const
   {

--- a/src/openms/source/FORMAT/ControlledVocabulary.cpp
+++ b/src/openms/source/FORMAT/ControlledVocabulary.cpp
@@ -500,8 +500,7 @@ namespace OpenMS
   const ControlledVocabulary::CVTerm* ControlledVocabulary::checkAndGetTermByName(const OpenMS::String& name) const
   {
     Map<String, String>::const_iterator it = namesToIds_.find(name);
-    if (it == namesToIds_.end())
-      return nullptr;
+    if (it == namesToIds_.end()) return nullptr;
     return &terms_[it->second];
   }
 

--- a/src/openms/source/FORMAT/ControlledVocabulary.cpp
+++ b/src/openms/source/FORMAT/ControlledVocabulary.cpp
@@ -458,24 +458,14 @@ namespace OpenMS
     return terms_;
   }
 
-  bool ControlledVocabulary::containsTermRecursively(const String& parent, const String& search) const
-  {
-    for (const auto& it : getTerm(parent).children)
-    {
-      if (it == search) return true;
-      else if (containsTermRecursively(it, search)) return true;
-    }
-    return false;
-  }
-
   void ControlledVocabulary::getAllChildTerms(set<String>& terms, const String& parent) const
   {
     //cerr << "Parent: " << parent << "\n";
-    for (const auto& it : getTerm(parent).children)
+    for (const auto& child : getTerm(parent).children)
     {
-      terms.insert(it);
+      terms.insert(child);
       //TODO: This is not safe for cyclic graphs. Are they allowed in CVs?
-      getAllChildTerms(terms, it);
+      getAllChildTerms(terms, child);
     }
   }
 

--- a/src/openms/source/FORMAT/ControlledVocabulary.cpp
+++ b/src/openms/source/FORMAT/ControlledVocabulary.cpp
@@ -497,6 +497,15 @@ namespace OpenMS
     return terms_.has(id);
   }
 
+  bool ControlledVocabulary::checkAndGetTermByName(const OpenMS::String& name, ControlledVocabulary::CVTerm& c) const
+  {
+    Map<String, String>::const_iterator it = namesToIds_.find(name);
+    if (it == namesToIds_.end())
+      return false;
+    c = terms_[it->second];
+    return true;
+  }
+
   bool ControlledVocabulary::hasTermWithName(const OpenMS::String& name) const
   {
     Map<String, String>::const_iterator it = namesToIds_.find(name);

--- a/src/openms/source/FORMAT/ControlledVocabulary.cpp
+++ b/src/openms/source/FORMAT/ControlledVocabulary.cpp
@@ -497,13 +497,12 @@ namespace OpenMS
     return terms_.has(id);
   }
 
-  bool ControlledVocabulary::checkAndGetTermByName(const OpenMS::String& name, ControlledVocabulary::CVTerm& c) const
+  const ControlledVocabulary::CVTerm* ControlledVocabulary::checkAndGetTermByName(const OpenMS::String& name) const
   {
     Map<String, String>::const_iterator it = namesToIds_.find(name);
     if (it == namesToIds_.end())
-      return false;
-    c = terms_[it->second];
-    return true;
+      return nullptr;
+    return &terms_[it->second];
   }
 
   bool ControlledVocabulary::hasTermWithName(const OpenMS::String& name) const

--- a/src/openms/source/FORMAT/ControlledVocabulary.cpp
+++ b/src/openms/source/FORMAT/ControlledVocabulary.cpp
@@ -458,6 +458,18 @@ namespace OpenMS
     return terms_;
   }
 
+#if 1
+  bool ControlledVocabulary::containsTermRecursively(const String& parent, const String& search) const
+  {
+    for (const auto& it : getTerm(parent).children)
+    {
+      if (it == search) return true;
+      else if (containsTermRecursively(it, search)) return true;
+    }
+    return false;
+  }
+#endif
+
   void ControlledVocabulary::getAllChildTerms(set<String>& terms, const String& parent) const
   {
     //cerr << "Parent: " << parent << "\n";

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -3449,10 +3449,10 @@ namespace OpenMS
 
         if (*key == "GO cellular component" || *key == "brenda source tissue")
         {
-          // the CVTerm info is in the value
+          // the CVTerm info is in the meta value
           const ControlledVocabulary::CVTerm* c = cv_.checkAndGetTermByName(meta.getMetaValue(*key));
 
-          if (c)
+          if (c != nullptr)
           {
             // TODO: validate CV, we currently cannot do this as the relations in the BTO and GO are not captured by our CV impl
             cvParams.push_back(writeCV_(*c, DataValue::EMPTY));
@@ -3462,7 +3462,7 @@ namespace OpenMS
         {
           bool writtenAsCVTerm = false;
           const ControlledVocabulary::CVTerm* c = cv_.checkAndGetTermByName(*key);
-          if (c)
+          if (c != nullptr)
           {
             if (validateCV_(*c, path, validator))
             {

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -3378,7 +3378,6 @@ namespace OpenMS
     bool MzMLHandler::validateCV_(const ControlledVocabulary::CVTerm& c, const String& path, const Internal::MzMLValidator& validator)
     {
       // static map<<Path, c.id>, isValid> for storing, if a cvterm is valid in the given path
-      // When not used as static function variable (when constructed in writeUserParam_() and passed by reference), we lose half of the speed-up
       const auto it = cached_terms_.find(std::make_pair(path, c.id));
       if (it != cached_terms_.end())
       {

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -3451,14 +3451,12 @@ namespace OpenMS
         if (*key == "GO cellular component" || *key == "brenda source tissue")
         {
           // the CVTerm info is in the value
-          const DataValue& metaValue = meta.getMetaValue(*key);
+          const ControlledVocabulary::CVTerm* c = cv_.checkAndGetTermByName(meta.getMetaValue(*key));
 
-          if (cv_.hasTermWithName((String) metaValue))
+          if (c)
           {
-            ControlledVocabulary::CVTerm c = cv_.getTermByName((String) metaValue);
-
             // TODO: validate CV, we currently cannot do this as the relations in the BTO and GO are not captured by our CV impl
-            cvParams.push_back(writeCV_(c, DataValue::EMPTY));
+            cvParams.push_back(writeCV_(*c, DataValue::EMPTY));
           }
         }
         else

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -3375,7 +3375,7 @@ namespace OpenMS
       }
     }
 
-    bool MzMLHandler::validateCV_(const ControlledVocabulary::CVTerm& c, const String& path, const Internal::MzMLValidator& validator)
+    bool MzMLHandler::validateCV_(const ControlledVocabulary::CVTerm& c, const String& path, const Internal::MzMLValidator& validator) const
     {
       // static map<<Path, c.id>, isValid> for storing, if a cvterm is valid in the given path
       const auto it = cached_terms_.find(std::make_pair(path, c.id));
@@ -3432,7 +3432,7 @@ namespace OpenMS
       return cvTerm;
     }
 
-    void MzMLHandler::writeUserParam_(std::ostream& os, const MetaInfoInterface& meta, UInt indent, const String& path, const Internal::MzMLValidator& validator, const std::set<String>& exclude)
+    void MzMLHandler::writeUserParam_(std::ostream& os, const MetaInfoInterface& meta, UInt indent, const String& path, const Internal::MzMLValidator& validator, const std::set<String>& exclude) const
     {
       std::vector<String> cvParams;
       std::vector<String> userParams;

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -3546,16 +3546,6 @@ namespace OpenMS
 
     ControlledVocabulary::CVTerm MzMLHandler::getChildWithName_(const String& parent_accession, const String& name) const
     {
-      //std::set<String> terms;
-      //cv_.getAllChildTerms(terms, parent_accession);
-      //for (std::set<String>::const_iterator it = terms.begin(); it != terms.end(); ++it)
-      //{
-      //  if (cv_.getTerm(*it).name == name)
-      //  {
-      //    return cv_.getTerm(*it);
-      //  }
-      //}
-      //return ControlledVocabulary::CVTerm();
       ControlledVocabulary::CVTerm res = ControlledVocabulary::CVTerm();
       auto searcher = [&res, &name, this] (const String& child)
       {

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -3465,10 +3465,8 @@ namespace OpenMS
         {
           bool writtenAsCVTerm = false;
           const ControlledVocabulary::CVTerm* c = cv_.checkAndGetTermByName(*key);
-          //if (cv_.hasTermWithName(*key))
           if (c)
           {
-            //ControlledVocabulary::CVTerm c = cv_.getTermByName(*key); // in cv_ write cvparam else write userparam
             if (validateCV_(*c, path, validator))
             {
               // write CV

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -3538,16 +3538,29 @@ namespace OpenMS
 
     ControlledVocabulary::CVTerm MzMLHandler::getChildWithName_(const String& parent_accession, const String& name) const
     {
-      std::set<String> terms;
-      cv_.getAllChildTerms(terms, parent_accession);
-      for (std::set<String>::const_iterator it = terms.begin(); it != terms.end(); ++it)
+      //std::set<String> terms;
+      //cv_.getAllChildTerms(terms, parent_accession);
+      //for (std::set<String>::const_iterator it = terms.begin(); it != terms.end(); ++it)
+      //{
+      //  if (cv_.getTerm(*it).name == name)
+      //  {
+      //    return cv_.getTerm(*it);
+      //  }
+      //}
+      //return ControlledVocabulary::CVTerm();
+      ControlledVocabulary::CVTerm res = ControlledVocabulary::CVTerm();
+      auto searcher = [&res, &name, this] (const String& child)
       {
-        if (cv_.getTerm(*it).name == name)
+        const ControlledVocabulary::CVTerm& current = this->cv_.getTerm(child);
+        if (current.name == name)
         {
-          return cv_.getTerm(*it);
+          res = current;
+          return true;
         }
-      }
-      return ControlledVocabulary::CVTerm();
+        return false;
+      };
+      cv_.iterateAllChildren(parent_accession, searcher);
+      return res;
     }
 
     void MzMLHandler::writeSoftware_(std::ostream& os, const String& id, const Software& software, const Internal::MzMLValidator& validator)

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -3375,12 +3375,12 @@ namespace OpenMS
       }
     }
 
-    bool MzMLHandler::validateCV_(const ControlledVocabulary::CVTerm& c, const String& path, const Internal::MzMLValidator& validator) const
+    bool MzMLHandler::validateCV_(const ControlledVocabulary::CVTerm& c, const String& path, const Internal::MzMLValidator& validator)
     {
       // static map<<Path, c.id>, isValid> for storing, if a cvterm is valid in the given path
-      static std::map<std::pair<String, String>, bool> cachedTerms;
-      const auto it = cachedTerms.find(std::make_pair(path, c.id));
-      if (it != cachedTerms.end())
+      // When not used as static function variable (when constructed in writeUserParam_() and passed by reference), we lose half of the speed-up
+      const auto it = cached_terms_.find(std::make_pair(path, c.id));
+      if (it != cached_terms_.end())
       {
         return it->second;
       }
@@ -3392,7 +3392,7 @@ namespace OpenMS
       sc.has_unit_name = false;
 
       bool isValid = validator.SemanticValidator::locateTerm(path, sc);
-      cachedTerms[std::make_pair(path, c.id)] = isValid;
+      cached_terms_[std::make_pair(path, c.id)] = isValid;
       return isValid;
     }
 
@@ -3433,7 +3433,7 @@ namespace OpenMS
       return cvTerm;
     }
 
-    void MzMLHandler::writeUserParam_(std::ostream& os, const MetaInfoInterface& meta, UInt indent, const String& path, const Internal::MzMLValidator& validator, const std::set<String>& exclude) const
+    void MzMLHandler::writeUserParam_(std::ostream& os, const MetaInfoInterface& meta, UInt indent, const String& path, const Internal::MzMLValidator& validator, const std::set<String>& exclude)
     {
       std::vector<String> cvParams;
       std::vector<String> userParams;

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -3377,7 +3377,11 @@ namespace OpenMS
 
     bool MzMLHandler::validateCV_(const ControlledVocabulary::CVTerm& c, const String& path, const Internal::MzMLValidator& validator) const
     {
-      // static map<<Path, c.id>, isValid> for storing, if a cvterm is valid in the given path
+      // We remember already validated path-term-combinations in cached_terms_
+      // This avoids recomputing SemanticValidator::locateTerm() multiple times for the same terms and paths
+      // validateCV_() is called very often for the same path-term-combinations, so we save lots of repetitive computations
+      // By caching these combinations we save about 99% of the runtime of validateCV_()
+
       const auto it = cached_terms_.find(std::make_pair(path, c.id));
       if (it != cached_terms_.end())
       {

--- a/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
+++ b/src/openms/source/FORMAT/HANDLERS/MzMLHandler.cpp
@@ -3543,7 +3543,7 @@ namespace OpenMS
 
     ControlledVocabulary::CVTerm MzMLHandler::getChildWithName_(const String& parent_accession, const String& name) const
     {
-      ControlledVocabulary::CVTerm res = ControlledVocabulary::CVTerm();
+      ControlledVocabulary::CVTerm res;
       auto searcher = [&res, &name, this] (const String& child)
       {
         const ControlledVocabulary::CVTerm& current = this->cv_.getTerm(child);

--- a/src/openms/source/FORMAT/VALIDATORS/MzDataValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/MzDataValidator.cpp
@@ -83,7 +83,7 @@ namespace OpenMS
               if (child == parsed_term.accession)
               {
                 allowed = true;
-                counter++;
+                ++counter;
                 return true;
               }
               return false;

--- a/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
@@ -324,7 +324,7 @@ namespace OpenMS
             if (child == parsed_term.accession)
             {
               allowed = true;
-              counter++;
+              ++counter;
               return true;
             }
             return false;

--- a/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
@@ -564,7 +564,6 @@ namespace OpenMS
       const vector<CVMappingRule>& rules = rules_[path];
       for (Size r = 0; r < rules.size(); ++r) //go thru all rules
       {
-        //~ rule_found = true;
         for (Size t = 0; t < rules[r].getCVTerms().size(); ++t) //go thru all terms
         {
           const CVMappingTerm& term = rules[r].getCVTerms()[t];
@@ -572,7 +571,8 @@ namespace OpenMS
           {
             return true;
           }
-          if (term.getAllowChildren() && cv_.containsTermRecursively(term.getAccession(), parsed_term.accession)) //check if the term's children are allowed
+          auto searcher = [&parsed_term] (const String& child) { return child == parsed_term.accession; };
+          if (term.getAllowChildren() && cv_.iterateAllChildren(term.getAccession(), searcher))
           {
             return true;
           }

--- a/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
@@ -576,16 +576,18 @@ namespace OpenMS
           }
           if (term.getAllowChildren()) //check if the term's children are allowed
           {
-            set<String> child_terms;
-            cv_.getAllChildTerms(child_terms, term.getAccession());
-            for (set<String>::const_iterator it = child_terms.begin(); it != child_terms.end(); ++it)
-            {
-              if (*it == parsed_term.accession)
-              {
-                allowed = true;
-                break;
-              }
-            }
+            //set<String> child_terms;
+            //cv_.getAllChildTerms(child_terms, term.getAccession());
+            allowed = cv_.containsTermRecursively(term.getAccession(), parsed_term.accession);
+            //cv_.containsTerm();
+            //for (set<String>::const_iterator it = child_terms.begin(); it != child_terms.end(); ++it)
+            //{
+            //  if (*it == parsed_term.accession)
+            //  {
+            //    allowed = true;
+            //    break;
+            //  }
+            //}
           }
         }
       }

--- a/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
@@ -572,12 +572,9 @@ namespace OpenMS
           {
             return true;
           }
-          if (term.getAllowChildren()) //check if the term's children are allowed
+          if (term.getAllowChildren() && cv_.containsTermRecursively(term.getAccession(), parsed_term.accession)) //check if the term's children are allowed
           {
-            if (cv_.containsTermRecursively(term.getAccession(), parsed_term.accession))
-            {
-              return true;
-            }
+            return true;
           }
         }
       }

--- a/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
@@ -332,17 +332,6 @@ namespace OpenMS
           if (term.getAllowChildren() && cv_.iterateAllChildren(term.getAccession(), searcher)) //check if the term's children are allowed
           {
             break;
-            //set<String> child_terms;
-            //cv_.getAllChildTerms(child_terms, term.getAccession());
-            //for (set<String>::const_iterator it = child_terms.begin(); it != child_terms.end(); ++it)
-            //{
-            //  if (*it == parsed_term.accession)
-            //  {
-            //    allowed = true;
-            //    fulfilled_[path][rules[r].getIdentifier()][term.getAccession()]++;
-            //    break;
-            //  }
-            //}
           }
         }
       }
@@ -370,24 +359,18 @@ namespace OpenMS
                 set<String> child_terms;
 
                 bool found_unit(false);
+                auto lambda = [&parsed_term, &found_unit] (const String& child)
+                {
+                  if (child == parsed_term.accession)
+                  {
+                    found_unit = true;
+                    return true;
+                  }
+                  return false;
+                };
                 for (set<String>::const_iterator it = term.units.begin(); it != term.units.end(); ++it)
                 {
-                  auto lambda = [&parsed_term, &found_unit] (const String& child)
-                  {
-                    if (child == parsed_term.accession)
-                    {
-                      found_unit = true;
-                      return true;
-                    }
-                    return false;
-                  };
                   if (cv_.iterateAllChildren(*it, lambda)) break;
-                  //cv_.getAllChildTerms(child_terms, *it);
-                  //if (child_terms.find(parsed_term.unit_accession) != child_terms.end())
-                  //{
-                  //  found_unit = true;
-                  //  break;
-                  //}
                 }
 
                 if (!found_unit)

--- a/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
+++ b/src/openms/source/FORMAT/VALIDATORS/SemanticValidator.cpp
@@ -561,7 +561,6 @@ namespace OpenMS
       //check if the term is allowed in this element
       //and if there is a mapping rule for this element
       //Also store fulfilled rule term counts - this count is used to check of the MUST/MAY and AND/OR/XOR is fulfilled
-      bool allowed = false;
       const vector<CVMappingRule>& rules = rules_[path];
       for (Size r = 0; r < rules.size(); ++r) //go thru all rules
       {
@@ -571,28 +570,18 @@ namespace OpenMS
           const CVMappingTerm& term = rules[r].getCVTerms()[t];
           if (term.getUseTerm() && term.getAccession() == parsed_term.accession) //check if the term itself is allowed
           {
-            allowed = true;
-            break;
+            return true;
           }
           if (term.getAllowChildren()) //check if the term's children are allowed
           {
-            //set<String> child_terms;
-            //cv_.getAllChildTerms(child_terms, term.getAccession());
-            allowed = cv_.containsTermRecursively(term.getAccession(), parsed_term.accession);
-            //cv_.containsTerm();
-            //for (set<String>::const_iterator it = child_terms.begin(); it != child_terms.end(); ++it)
-            //{
-            //  if (*it == parsed_term.accession)
-            //  {
-            //    allowed = true;
-            //    break;
-            //  }
-            //}
+            if (cv_.containsTermRecursively(term.getAccession(), parsed_term.accession))
+            {
+              return true;
+            }
           }
         }
       }
-      return allowed;
+      return false;
     }
-
   } // namespace Internal
 } // namespace OpenMS


### PR DESCRIPTION
While measuring the performance of the FileConverter, we noticed, that the programm spends a lot of time in the recursive function ControlledVocabulary::getAllChildTerms() which builds a set of Strings.
As this set is not actually needed completely, an alternative function was then created to iterate over all children recursively without building the set. That function (iterateAllChildren()) takes a lambda-function which shall return a bool to decide if to quit the recursion.
The new function was applied where possible.

Furthermore, the search for an existing CVTerm in SematicValidator::locateTerm_() is very expensive and also done repeatedly for the same terms and paths. So, a map<pair<Path, CV-name>, bool> was created for MzMLHandler::validateCV_(), which is looked up to see if a term-path-combination was located already. Only if not included in the map, that combination is determined with locateTerm_().

These changes lead to a constant 50% speedup of MzMLFile::store().

![](https://user-images.githubusercontent.com/62887033/82430615-de5e2700-9a8d-11ea-98e2-125adfd7d4dc.png)
