### PR TITLE
 subsitute vector<double> for map<PeakType, double> in SignalToNoiseEstimator

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/MRMFeatureAccessOpenMS.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DATAACCESS/MRMFeatureAccessOpenMS.h
@@ -206,12 +206,12 @@ public:
       if (std::fabs(prev->getMZ() - RT) < std::fabs(iter->getMZ() - RT) )
       {
         // prev is closer to the apex
-        return sn_.getSignalToNoise(*prev);
+        return sn_.getSignalToNoise((Size) distance(chromatogram_.begin(),prev));
       }
       else
       {
         // iter is closer to the apex
-        return sn_.getSignalToNoise(*iter);
+        return sn_.getSignalToNoise((Size) distance(chromatogram_.begin(),iter));
       }
     }
 

--- a/src/openms/include/OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimator.h
+++ b/src/openms/include/OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimator.h
@@ -103,13 +103,11 @@ public:
     }
 
     ///Return to signal/noise estimate for date point @p index
-    ///@note the first query to this function will take longer, as
-    ///      all SignalToNoise values are calculated.
     ///@note you will get a warning to stderr if more than 20% of the
     ///      noise estimates used sparse windows
     virtual double getSignalToNoise(const Size index)
     {
-      OPENMS_POSTCONDITION(condition,message);
+      OPENMS_POSTCONDITION(index < stn_estimates_.size(),"SignalToNoiseEstimator estimates beyond container size was requested.");
       return stn_estimates_[index];
     }
 

--- a/src/openms/include/OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimator.h
+++ b/src/openms/include/OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimator.h
@@ -70,9 +70,7 @@ public:
     /// Constructor
     inline SignalToNoiseEstimator() :
       DefaultParamHandler("SignalToNoiseEstimator"),
-      ProgressLogger(),
-      c(),
-      is_result_valid_(false)
+      ProgressLogger()
     {
     }
 
@@ -80,9 +78,7 @@ public:
     inline SignalToNoiseEstimator(const SignalToNoiseEstimator & source) :
       DefaultParamHandler(source),
       ProgressLogger(source),
-      stn_estimates_(source.stn_estimates_),
-      c(source.c),
-      is_result_valid_(source.is_result_valid_)
+      stn_estimates_(source.stn_estimates_)
     {}
 
     /// Assignment operator
@@ -93,7 +89,6 @@ public:
       DefaultParamHandler::operator=(source);
       ProgressLogger::operator=(source);
       stn_estimates_ = source.stn_estimates_;
-      c = source.c;
       return *this;
     }
 
@@ -105,22 +100,16 @@ public:
     virtual void init(const Container& c)
     {
       computeSTN_(c);
-      is_result_valid_ = true;
     }
 
     ///Return to signal/noise estimate for date point @p index
-    ///@note the first query to this function will taake longer, as
+    ///@note the first query to this function will take longer, as
     ///      all SignalToNoise values are calculated.
     ///@note you will get a warning to stderr if more than 20% of the
     ///      noise estimates used sparse windows
     virtual double getSignalToNoise(const Size index)
     {
-      if (!is_result_valid_)
-      {
-        // recompute ...
-        init(c);
-      }
-
+      OPENMS_POSTCONDITION(condition,message);
       return stn_estimates_[index];
     }
 
@@ -182,10 +171,6 @@ protected:
 
     /// stores the noise estimate for each peak
     std::vector<double> stn_estimates_;
-    /// raw data;
-    Container c;
-    /// flag: set to true if SignalToNoise estimates are calculated and none of the params were changed. otherwise false.
-    mutable bool is_result_valid_;
   };
 
 } // namespace OpenMS

--- a/src/openms/include/OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimatorMeanIterative.h
+++ b/src/openms/include/OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimatorMeanIterative.h
@@ -77,7 +77,6 @@ public:
     enum IntensityThresholdCalculation {MANUAL = -1, AUTOMAXBYSTDEV = 0, AUTOMAXBYPERCENT = 1};
 
     using SignalToNoiseEstimator<Container>::stn_estimates_;
-    using SignalToNoiseEstimator<Container>::is_result_valid_;
     using SignalToNoiseEstimator<Container>::defaults_;
     using SignalToNoiseEstimator<Container>::param_;
 
@@ -402,7 +401,7 @@ protected:
       stdev_                 = (double)param_.getValue("stdev_mp");
       min_required_elements_ = param_.getValue("min_required_elements");
       noise_for_empty_window_ = (double)param_.getValue("noise_for_empty_window");
-      is_result_valid_ = false;
+      stn_estimates_.clear();
     }
 
     /// maximal intensity considered during binning (values above get discarded)

--- a/src/openms/include/OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimatorMeanIterative.h
+++ b/src/openms/include/OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimatorMeanIterative.h
@@ -39,6 +39,7 @@
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <vector>
+#include <algorithm> //for std::max_element
 
 namespace OpenMS
 {
@@ -76,8 +77,6 @@ public:
     enum IntensityThresholdCalculation {MANUAL = -1, AUTOMAXBYSTDEV = 0, AUTOMAXBYPERCENT = 1};
 
     using SignalToNoiseEstimator<Container>::stn_estimates_;
-    using SignalToNoiseEstimator<Container>::first_;
-    using SignalToNoiseEstimator<Container>::last_;
     using SignalToNoiseEstimator<Container>::is_result_valid_;
     using SignalToNoiseEstimator<Container>::defaults_;
     using SignalToNoiseEstimator<Container>::param_;
@@ -164,17 +163,22 @@ protected:
 
 
     /** calculate StN values for all datapoints given, by using a sliding window approach
-                  @param scan_first_ first element in the scan
-                  @param scan_last_ last element in the scan (disregarded)
+                  @param c raw data
                   @exception Throws Exception::InvalidValue
            */
-    void computeSTN_(const PeakIterator & scan_first_, const PeakIterator & scan_last_) override
+    void computeSTN_(const Container& c) override
     {
+      //first element in the scan
+      PeakIterator scan_first_ = c.begin();
+      //last element in the scan
+      PeakIterator scan_last_ = c.end();
+
       // reset counter for sparse windows
       double sparse_window_percent = 0;
 
       // reset the results
       stn_estimates_.clear();
+      stn_estimates_.resize(c.size());
 
       // maximal range of histogram needs to be calculated first
       if (auto_mode_ == AUTOMAXBYSTDEV)
@@ -200,20 +204,13 @@ protected:
         std::vector<int> histogram_auto(100, 0);
 
         // find maximum of current scan
-        int size = 0;
-        typename PeakType::IntensityType maxInt = 0;
-        PeakIterator run = scan_first_;
-        while (run != scan_last_)
-        {
-          maxInt = std::max(maxInt, (*run).getIntensity());
-          ++size;
-          ++run;
-        }
+        auto maxIt = std::max_element(c.begin(), c.end() ,[](const PeakType& a, const PeakType& b){ return a.getIntensity() > b.getIntensity();});
+        typename PeakType::IntensityType maxInt = maxIt->getIntensity();
 
         double bin_size = maxInt / 100;
 
         // fill histogram
-        run = scan_first_;
+        PeakIterator run = scan_first_;
         while (run != scan_last_)
         {
           ++histogram_auto[(int) (((*run).getIntensity() - 1) / bin_size)];
@@ -221,7 +218,7 @@ protected:
         }
 
         // add up element counts in histogram until ?th percentile is reached
-        int elements_below_percentile = (int) (auto_max_percentile_ * size / 100);
+        int elements_below_percentile = (int) (auto_max_percentile_ * c.size() / 100);
         int elements_seen = 0;
         int i = -1;
         run = scan_first_;
@@ -283,15 +280,8 @@ protected:
 
       double noise;      // noise value of a datapoint
 
-      // determine how many elements we need to estimate (for progress estimation)
-      int windows_overall = 0;
-      PeakIterator run = scan_first_;
-      while (run != scan_last_)
-      {
-        ++windows_overall;
-        ++run;
-      }
-      SignalToNoiseEstimator<Container>::startProgress(0, windows_overall, "noise estimation of data");
+      ///start progress estimation
+      SignalToNoiseEstimator<Container>::startProgress(0, c.size(), "noise estimation of data");
 
       // MAIN LOOP
       while (window_pos_center != scan_last_)
@@ -370,7 +360,7 @@ protected:
         }
 
         // store result
-        stn_estimates_[*window_pos_center] = (*window_pos_center).getIntensity() / noise;
+        stn_estimates_[window_count] = (*window_pos_center).getIntensity() / noise;
 
 
 

--- a/src/openms/include/OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimatorMedian.h
+++ b/src/openms/include/OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimatorMedian.h
@@ -88,7 +88,6 @@ public:
     enum IntensityThresholdCalculation {MANUAL = -1, AUTOMAXBYSTDEV = 0, AUTOMAXBYPERCENT = 1};
 
     using SignalToNoiseEstimator<Container>::stn_estimates_;
-    using SignalToNoiseEstimator<Container>::is_result_valid_;
     using SignalToNoiseEstimator<Container>::defaults_;
     using SignalToNoiseEstimator<Container>::param_;
 
@@ -408,7 +407,7 @@ protected:
       min_required_elements_   = param_.getValue("min_required_elements");
       noise_for_empty_window_  = (double)param_.getValue("noise_for_empty_window");
       write_log_messages_      = (bool)param_.getValue("write_log_messages").toBool();
-      is_result_valid_         = false;
+      stn_estimates_.clear();
     }
 
     /// maximal intensity considered during binning (values above get discarded)

--- a/src/openms/include/OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimatorMedian.h
+++ b/src/openms/include/OpenMS/FILTERING/NOISEESTIMATION/SignalToNoiseEstimatorMedian.h
@@ -41,6 +41,7 @@
 #include <OpenMS/CONCEPT/Exception.h>
 #include <OpenMS/DATASTRUCTURES/ListUtils.h>
 #include <vector>
+#include <algorithm> //for std::max_element
 
 namespace OpenMS
 {
@@ -87,8 +88,6 @@ public:
     enum IntensityThresholdCalculation {MANUAL = -1, AUTOMAXBYSTDEV = 0, AUTOMAXBYPERCENT = 1};
 
     using SignalToNoiseEstimator<Container>::stn_estimates_;
-    using SignalToNoiseEstimator<Container>::first_;
-    using SignalToNoiseEstimator<Container>::last_;
     using SignalToNoiseEstimator<Container>::is_result_valid_;
     using SignalToNoiseEstimator<Container>::defaults_;
     using SignalToNoiseEstimator<Container>::param_;
@@ -184,12 +183,16 @@ protected:
 
     /** Calculate signal-to-noise values for all data points given, by using a sliding window approach
      
-        @param scan_first_ first element in the scan
-        @param scan_last_ last element in the scan (disregarded)
+        @param c raw data
         @exception Throws Exception::InvalidValue
     */
-    void computeSTN_(const PeakIterator & scan_first_, const PeakIterator & scan_last_) override
+    void computeSTN_(const Container& c) override
     {
+      //first element in the scan
+      PeakIterator scan_first_ = c.begin();
+      //last element in the scan
+      PeakIterator scan_last_ = c.end();
+
       // reset counter for sparse windows
       sparse_window_percent_ = 0;
       // reset counter for histogram overflow
@@ -197,6 +200,7 @@ protected:
 
       // reset the results
       stn_estimates_.clear();
+      stn_estimates_.resize(c.size());
 
       // maximal range of histogram needs to be calculated first
       if (auto_mode_ == AUTOMAXBYSTDEV)
@@ -222,20 +226,13 @@ protected:
         std::vector<int> histogram_auto(100, 0);
 
         // find maximum of current scan
-        int size = 0;
-        typename PeakType::IntensityType maxInt = 0;
-        PeakIterator run = scan_first_;
-        while (run != scan_last_)
-        {
-          maxInt = std::max(maxInt, (*run).getIntensity());
-          ++size;
-          ++run;
-        }
+        auto maxIt = std::max_element(c.begin(), c.end() ,[](const PeakType& a, const PeakType& b){ return a.getIntensity() > b.getIntensity();});
+        typename PeakType::IntensityType maxInt = maxIt->getIntensity();
 
         double bin_size = maxInt / 100;
 
         // fill histogram
-        run = scan_first_;
+        PeakIterator run = scan_first_;
         while (run != scan_last_)
         {
           ++histogram_auto[(int) (((*run).getIntensity() - 1) / bin_size)];
@@ -243,7 +240,7 @@ protected:
         }
 
         // add up element counts in histogram until ?th percentile is reached
-        int elements_below_percentile = (int) (auto_max_percentile_ * size / 100);
+        int elements_below_percentile = (int) (auto_max_percentile_ * c.size() / 100);
         int elements_seen = 0;
         int i = -1;
         run = scan_first_;
@@ -310,15 +307,8 @@ protected:
 
       double noise;    // noise value of a datapoint
 
-      // determine how many elements we need to estimate (for progress estimation)
-      int windows_overall = 0;
-      PeakIterator run = scan_first_;
-      while (run != scan_last_)
-      {
-        ++windows_overall;
-        ++run;
-      }
-      SignalToNoiseEstimator<Container>::startProgress(0, windows_overall, "noise estimation of data");
+      ///start progress estimation
+      SignalToNoiseEstimator<Container>::startProgress(0, c.size(), "noise estimation of data");
 
       // MAIN LOOP
       while (window_pos_center != scan_last_)
@@ -369,7 +359,7 @@ protected:
         }
 
         // store result
-        stn_estimates_[*window_pos_center] = (*window_pos_center).getIntensity() / noise;
+        stn_estimates_[window_count] = (*window_pos_center).getIntensity() / noise;
 
 
         // advance the window center by one datapoint

--- a/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerIterative.h
+++ b/src/openms/include/OpenMS/TRANSFORMATIONS/RAW2PEAK/PeakPickerIterative.h
@@ -209,7 +209,7 @@ private:
         {
           if (signal_to_noise_ > 0.0)
           {
-            if (snt.getSignalToNoise(input[i - k]) < signal_to_noise_)
+            if (snt.getSignalToNoise(i - k) < signal_to_noise_)
             {
               break;
             }
@@ -229,7 +229,7 @@ private:
         {
           if (signal_to_noise_ > 0.0)
           {
-            if (snt.getSignalToNoise(input[i + k]) < signal_to_noise_)
+            if (snt.getSignalToNoise(i + k) < signal_to_noise_)
             {
               break;
             }

--- a/src/openms/source/ANALYSIS/OPENSWATH/PeakPickerMRM.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/PeakPickerMRM.cpp
@@ -198,7 +198,7 @@ namespace OpenMS
              //&& std::fabs(chromatogram[min_i-k].getMZ() - peak_raw_data.begin()->first) < spacing_difference*min_spacing
             && (chromatogram[min_i - k].getIntensity() < chromatogram[min_i - k + 1].getIntensity()
                || (peak_width_ > 0.0 && std::fabs(chromatogram[min_i - k].getRT() - central_peak_rt) < peak_width_))
-            && (signal_to_noise_ <= 0.0 || snt_.getSignalToNoise(chromatogram[min_i - k]) >= signal_to_noise_))
+            && (signal_to_noise_ <= 0.0 || snt_.getSignalToNoise(min_i - k) >= signal_to_noise_))
       {
         ++k;
       }
@@ -210,7 +210,7 @@ namespace OpenMS
              //&& std::fabs(chromatogram[min_i+k].getMZ() - peak_raw_data.rbegin()->first) < spacing_difference*min_spacing
             && (chromatogram[min_i + k].getIntensity() < chromatogram[min_i + k - 1].getIntensity()
                || (peak_width_ > 0.0 && std::fabs(chromatogram[min_i + k].getRT() - central_peak_rt) < peak_width_))
-            && (signal_to_noise_ <= 0.0 || snt_.getSignalToNoise(chromatogram[min_i + k]) >= signal_to_noise_) )
+            && (signal_to_noise_ <= 0.0 || snt_.getSignalToNoise(min_i + k) >= signal_to_noise_) )
       {
         ++k;
       }

--- a/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/TargetedSpectraExtractor.cpp
@@ -325,11 +325,9 @@ namespace OpenMS
       p.setValue("noise_for_empty_window", 2.0);
       p.setValue("min_required_elements", 10);
       sne.setParameters(p);
-      sne.init(annotated_spectra[i].begin(), annotated_spectra[i].end());
+      sne.init(annotated_spectra[i]);
       double avgSNR { 0 };
-      for (MSSpectrum::const_iterator it = annotated_spectra[i].begin();
-           it != annotated_spectra[i].end();
-           ++it)
+      for (Size it = 0; it < annotated_spectra[i].size(); ++it)
       {
         avgSNR += sne.getSignalToNoise(it);
       }

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmMRM.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmMRM.cpp
@@ -176,17 +176,17 @@ namespace OpenMS
       }
 
       PeakSpectrum::FloatDataArray signal_to_noise;
-      for (Size sit = 0; sit < chromatogram.size(); ++sit)
+      for (Size i = 0; i < chromatogram.size(); ++i)
       {
-        double sn(sne.getSignalToNoise(sit));
+        double sn(sne.getSignalToNoise(i));
         signal_to_noise.push_back(sn);
         if (write_debuginfo)
         {
-          std::cerr << chromatogram[sit].getMZ() << " " << chromatogram[sit].getIntensity() << " " << sn << std::endl;
+          std::cerr << chromatogram[i].getMZ() << " " << chromatogram[i].getIntensity() << " " << sn << std::endl;
         }
         if (min_signal_to_noise_ratio == 0 || sn > min_signal_to_noise_ratio)
         {
-          sn_chrom.push_back(chromatogram[sit]);
+          sn_chrom.push_back(chromatogram[i]);
         }
       }
       chromatogram.getFloatDataArrays().push_back(signal_to_noise);

--- a/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmMRM.cpp
+++ b/src/openms/source/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmMRM.cpp
@@ -168,7 +168,7 @@ namespace OpenMS
         continue;
       }
       sne.setParameters(sne_param);
-      sne.init(chromatogram.begin(), chromatogram.end());
+      sne.init(chromatogram);
 
       if (write_debuginfo)
       {
@@ -176,17 +176,17 @@ namespace OpenMS
       }
 
       PeakSpectrum::FloatDataArray signal_to_noise;
-      for (PeakSpectrum::Iterator sit = chromatogram.begin(); sit != chromatogram.end(); ++sit)
+      for (Size sit = 0; sit < chromatogram.size(); ++sit)
       {
         double sn(sne.getSignalToNoise(sit));
         signal_to_noise.push_back(sn);
         if (write_debuginfo)
         {
-          std::cerr << sit->getMZ() << " " << sit->getIntensity() << " " << sn << std::endl;
+          std::cerr << chromatogram[sit].getMZ() << " " << chromatogram[sit].getIntensity() << " " << sn << std::endl;
         }
         if (min_signal_to_noise_ratio == 0 || sn > min_signal_to_noise_ratio)
         {
-          sn_chrom.push_back(*sit);
+          sn_chrom.push_back(chromatogram[sit]);
         }
       }
       chromatogram.getFloatDataArrays().push_back(signal_to_noise);

--- a/src/openms/source/TRANSFORMATIONS/RAW2PEAK/PeakPickerCWT.cpp
+++ b/src/openms/source/TRANSFORMATIONS/RAW2PEAK/PeakPickerCWT.cpp
@@ -1142,7 +1142,7 @@ namespace OpenMS
     PeakIterator it_pick_begin = raw_peak_array.begin();
     PeakIterator it_pick_end   = raw_peak_array.end();
 
-    sne.init(it_pick_begin, it_pick_end);
+    sne.init(raw_peak_array);
 
     // Upper peak width bound
     double fwhm_upper_bound = (double)param_.getValue("fwhm_upper_bound_factor") * scale_;
@@ -1179,7 +1179,7 @@ namespace OpenMS
       {
         // if the signal to noise ratio at the max position is too small
         // the peak isn't considered
-        if ((area.max != it_pick_end) && (sne.getSignalToNoise(area.max) < signal_to_noise_))
+        if ((area.max != it_pick_end) && (sne.getSignalToNoise((Size) distance(raw_peak_array.begin(),area.max)) < signal_to_noise_))
         {
           it_pick_begin = area.max;
           distance_from_scan_border = distance(raw_peak_array.begin(), it_pick_begin);
@@ -1222,7 +1222,7 @@ namespace OpenMS
              && (shape.getFWHM() >= fwhm_bound_)
              && (shape.getFWHM() <= fwhm_upper_bound))
           {
-            shape.signal_to_noise = sne.getSignalToNoise(area.max);
+            shape.signal_to_noise = sne.getSignalToNoise((Size) distance(raw_peak_array.begin(),area.max));
             peak_shapes.push_back(shape);
             ++number_of_peaks;
           }

--- a/src/openms/source/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.cpp
+++ b/src/openms/source/TRANSFORMATIONS/RAW2PEAK/PeakPickerHiRes.cpp
@@ -170,9 +170,9 @@ namespace OpenMS
       double act_snt = 0.0, act_snt_l1 = 0.0, act_snt_r1 = 0.0;
       if (signal_to_noise_ > 0.0)
       {
-        act_snt = snt.getSignalToNoise(input[i]);
-        act_snt_l1 = snt.getSignalToNoise(input[i - 1]);
-        act_snt_r1 = snt.getSignalToNoise(input[i + 1]);
+        act_snt = snt.getSignalToNoise(i);
+        act_snt_l1 = snt.getSignalToNoise(i - 1);
+        act_snt_r1 = snt.getSignalToNoise(i + 1);
       }
 
       // look for peak cores meeting MZ and intensity/SNT criteria
@@ -193,8 +193,8 @@ namespace OpenMS
 
         if (signal_to_noise_ > 0.0)
         {
-          act_snt_l2 = snt.getSignalToNoise(input[i - 2]);
-          act_snt_r2 = snt.getSignalToNoise(input[i + 2]);
+          act_snt_l2 = snt.getSignalToNoise(i - 2);
+          act_snt_r2 = snt.getSignalToNoise(i + 2);
         }
 
         // checking signal-to-noise?
@@ -238,7 +238,7 @@ namespace OpenMS
 
           if (signal_to_noise_ > 0.0)
           {
-            act_snt_lk = snt.getSignalToNoise(input[i - k]);
+            act_snt_lk = snt.getSignalToNoise(i - k);
           }
 
           if ((act_snt_lk >= signal_to_noise_) && 
@@ -279,7 +279,7 @@ namespace OpenMS
 
           if (signal_to_noise_ > 0.0)
           {
-            act_snt_rk = snt.getSignalToNoise(input[i + k]);
+            act_snt_rk = snt.getSignalToNoise(i + k);
           }
 
           if ((act_snt_rk >= signal_to_noise_) && 

--- a/src/tests/class_tests/openms/source/SignalToNoiseEstimatorMeanIterative_test.cpp
+++ b/src/tests/class_tests/openms/source/SignalToNoiseEstimatorMeanIterative_test.cpp
@@ -82,7 +82,7 @@ START_SECTION((virtual ~SignalToNoiseEstimatorMeanIterative()))
 END_SECTION
 
 
-START_SECTION([EXTRA](virtual void init(const PeakIterator& it_begin, const PeakIterator& it_end)))
+START_SECTION([EXTRA](virtual void init(const Container& c)))
 
 	TOLERANCE_ABSOLUTE(0.5)
 
@@ -90,38 +90,37 @@ START_SECTION([EXTRA](virtual void init(const PeakIterator& it_begin, const Peak
   MSSpectrum::const_iterator it;
   DTAFile dta_file;
   dta_file.load(OPENMS_GET_TEST_DATA_PATH("SignalToNoiseEstimator_test.dta"), raw_data);
-  
-    
-  SignalToNoiseEstimatorMeanIterative<> sne;  
+
+  SignalToNoiseEstimatorMeanIterative<> sne;
 	Param p;
 	p.setValue("win_len", 40.1);
 	p.setValue("noise_for_empty_window", 2.0);
 	p.setValue("min_required_elements", 10);
 	sne.setParameters(p);
-  sne.init(raw_data.begin(),raw_data.end());
+  sne.init(raw_data);
 
   MSSpectrum stn_data;
-  
+
 #ifdef DEBUG_TEST
   MSSpectrum stn_data__;
 #endif
-  
+
   dta_file.load(OPENMS_GET_TEST_DATA_PATH("SignalToNoiseEstimatorMeanIterative_test.out"), stn_data);
   int i = 0;
   for (it=raw_data.begin();it!=raw_data.end(); ++it)
   {
-    TEST_REAL_SIMILAR (stn_data[i].getIntensity(), sne.getSignalToNoise(it));
-#ifdef DEBUG_TEST    
+    TEST_REAL_SIMILAR (stn_data[i].getIntensity(), sne.getSignalToNoise(i));
+#ifdef DEBUG_TEST
     Peak1D peak = (*it);
     peak.setIntensity(stn_data[i].getIntensity() / sne.getSignalToNoise(it));
     stn_data__.push_back(peak);
-#endif    
+#endif
     ++i;
   }
-  
+
 #ifdef DEBUG_TEST
   dta_file.store(OPENMS_GET_TEST_DATA_PATH("SignalToNoiseEstimatorMeanIterative_test.debug"), stn_data__);
-#endif  
+#endif
   
 END_SECTION
 

--- a/src/tests/class_tests/openms/source/SignalToNoiseEstimatorMedian_test.cpp
+++ b/src/tests/class_tests/openms/source/SignalToNoiseEstimatorMedian_test.cpp
@@ -77,7 +77,7 @@ START_SECTION((virtual ~SignalToNoiseEstimatorMedian()))
 END_SECTION
 
 
-START_SECTION([EXTRA](virtual void init(const PeakIterator& it_begin, const PeakIterator& it_end)))
+START_SECTION([EXTRA](virtual void init(const Container& c)))
 
   MSSpectrum raw_data;
   MSSpectrum::const_iterator it;
@@ -91,14 +91,14 @@ START_SECTION([EXTRA](virtual void init(const PeakIterator& it_begin, const Peak
 	p.setValue("noise_for_empty_window", 2.0);
 	p.setValue("min_required_elements", 10);
 	sne.setParameters(p);
-  sne.init(raw_data.begin(),raw_data.end());
+  sne.init(raw_data);
 
   MSSpectrum stn_data;
   dta_file.load(OPENMS_GET_TEST_DATA_PATH("SignalToNoiseEstimatorMedian_test.out"), stn_data);
   int i = 0;
   for (it=raw_data.begin();it!=raw_data.end(); ++it)
   {
-    TEST_REAL_SIMILAR (stn_data[i].getIntensity(), sne.getSignalToNoise(it));
+    TEST_REAL_SIMILAR (stn_data[i].getIntensity(), sne.getSignalToNoise(i));
         
     
     //Peak1D peak = (*it);

--- a/src/tests/class_tests/openms/source/SignalToNoiseEstimator_test.cpp
+++ b/src/tests/class_tests/openms/source/SignalToNoiseEstimator_test.cpp
@@ -67,10 +67,10 @@ class TestSignalToNoiseEstimator
 
   protected:
 
-  void computeSTN_(const PeakIterator& scan_first_, const PeakIterator& scan_last_)
+  void computeSTN_(const MSSpectrum& C)
       throw() override
   {
-    if (scan_first_ == scan_last_)
+    if (C.begin() == C.end())
     {
       std::cout << "bla";
     }
@@ -95,7 +95,7 @@ END_SECTION
 START_SECTION((SignalToNoiseEstimator(const SignalToNoiseEstimator &source)))
   TestSignalToNoiseEstimator sne;
   MSSpectrum spec;
-  sne.init(spec.begin(), spec.end());
+  sne.init(spec);
   TestSignalToNoiseEstimator sne_copy(sne);
 	NOT_TESTABLE
 END_SECTION
@@ -104,7 +104,7 @@ END_SECTION
 START_SECTION((SignalToNoiseEstimator& operator=(const SignalToNoiseEstimator &source)))
   TestSignalToNoiseEstimator sne;
   MSSpectrum spec;
-  sne.init(spec.begin(), spec.end());
+  sne.init(spec);
   TestSignalToNoiseEstimator sne_copy;
   sne_copy = sne;
 	NOT_TESTABLE
@@ -116,13 +116,6 @@ START_SECTION((virtual ~SignalToNoiseEstimator()))
 END_SECTION
 
 
-START_SECTION((virtual void init(const PeakIterator& it_begin, const PeakIterator& it_end)))
-  TestSignalToNoiseEstimator sne;
-  MSSpectrum spec;
-  sne.init(spec.begin(), spec.end());
-	NOT_TESTABLE
-END_SECTION
-
 START_SECTION((virtual void init(const Container& c)))
   TestSignalToNoiseEstimator sne;
   MSSpectrum spec;
@@ -130,12 +123,8 @@ START_SECTION((virtual void init(const Container& c)))
 	NOT_TESTABLE
 END_SECTION
 
-START_SECTION((virtual double getSignalToNoise(const PeakIterator& data_point)))
-  // hard to do without implementing computeSTN_ properly
-	NOT_TESTABLE
-END_SECTION
 
-START_SECTION((virtual double getSignalToNoise(const PeakType &data_point)))
+START_SECTION((virtual double getSignalToNoise(const Size index)))
   // hard to do without implementing computeSTN_ properly
 	NOT_TESTABLE
 END_SECTION

--- a/src/topp/EICExtractor.cpp
+++ b/src/topp/EICExtractor.cpp
@@ -338,7 +338,7 @@ public:
           {
             Peak1D peak;
             peak.setMZ(tic[is].getMZ());
-            peak.setIntensity(snt.getSignalToNoise(tics[is]));
+            peak.setIntensity(snt.getSignalToNoise(is));
             tics_sn.push_back(peak);
           }
           out_debug.addChromatogram(toChromatogram(tics_sn));

--- a/src/topp/FileFilter.cpp
+++ b/src/topp/FileFilter.cpp
@@ -851,14 +851,14 @@ protected:
         SignalToNoiseEstimatorMedian<MapType::SpectrumType> snm;
         Param const& dc_param = getParam_().copy("algorithm:SignalToNoise:", true);
         snm.setParameters(dc_param);
-        for (MapType::Iterator it = exp.begin(); it != exp.end(); ++it)
+        for (Size it = 0; it != exp.size(); ++it)
         {
-          snm.init(it->begin(), it->end());
-          for (MapType::SpectrumType::Iterator spec = it->begin(); spec != it->end(); ++spec)
+          snm.init(exp[it]);
+          for (Size spec = 0; spec != exp[it].size(); ++spec)
           {
-            if (snm.getSignalToNoise(spec) < sn) spec->setIntensity(0);
+            if (snm.getSignalToNoise(spec) < sn) exp[it][spec].setIntensity(0);
           }
-          it->erase(remove_if(it->begin(), it->end(), InIntensityRange<MapType::PeakType>(1, numeric_limits<MapType::PeakType::IntensityType>::max(), true)), it->end());
+          exp[it].erase(remove_if(exp[it].begin(), exp[it].end(), InIntensityRange<MapType::PeakType>(1, numeric_limits<MapType::PeakType::IntensityType>::max(), true)), exp[it].end());
         }
       }
 


### PR DESCRIPTION
It coud be found that the type pf data, map<PeakType, doule>, was used in SignalToNoiseEstimator of Tool OpenSwathWorkflow, in which the values corresponded to the iteration of map are storaged. The stored values are synchronously updated contiguously with the iteration, using the function named getSignalToNoise. However, vector could be more efficient when processing large amounts of data. Thus, vectors are applied here. From the diagram shown below, it could be easily found that the processing speed differs a lot while using vector and map.(left: map | right: vector)
runtime of OpenSwathWorkflow with map: 17:31 m
runtime of OpenSwathWorkflow with vector: 15:38m
![Signal_Vergleiche](https://user-images.githubusercontent.com/62872209/83070287-8ca83480-a06b-11ea-971f-fb186231c918.JPG)
