### PR TITLE
Precomputation for DIAScoring and DIAHelper

### DIFF
--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DIAHelper.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DIAHelper.h
@@ -36,6 +36,7 @@
 
 #include <OpenMS/CHEMISTRY/AASequence.h>
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/DataStructures.h>
+#include <OpenMS/FILTERING/DATAREDUCTION/IsotopeDistributionCache.h>
 
 #include <vector>
 
@@ -110,14 +111,16 @@ namespace OpenMS
                                       UInt charge = 1u);
 
     /// get averagine distribution given mass
-    OPENMS_DLLAPI void getAveragineIsotopeDistribution(const double product_mz,
-                                         std::vector<std::pair<double, double> >& isotopesSpec,
-                                         const double charge = 1.,
-                                         const int nr_isotopes = 4,
-                                         const double mannmass = 1.00048);
+    OPENMS_DLLAPI void getAveragineIsotopeDistribution(IsotopeDistributionCache& iso,
+                                                       const double product_mz,
+                                                       std::vector<std::pair<double, double> >& isotopesSpec,
+                                                       const double charge = 1.,
+                                                       const int nr_isotopes = 4,
+                                                       const double mannmass = 1.00048);
 
     /// simulate spectrum from AASequence
-    OPENMS_DLLAPI void simulateSpectrumFromAASequence(const AASequence& aa,
+    OPENMS_DLLAPI void simulateSpectrumFromAASequence(IsotopeDistributionCache& iso,
+                                        const AASequence& aa,
                                         std::vector<double>& firstIsotopeMasses, //[out]
                                         std::vector<std::pair<double, double> >& isotopeMasses, //[out]
                                         TheoreticalSpectrumGenerator const * g,
@@ -137,7 +140,7 @@ namespace OpenMS
                               double charge = 1.);
 
     /// given an experimental spectrum add isotope pattern.
-    OPENMS_DLLAPI void addIsotopes2Spec(const std::vector<std::pair<double, double> >& spec,
+    OPENMS_DLLAPI void addIsotopes2Spec(IsotopeDistributionCache& iso, const std::vector<std::pair<double, double> >& spec,
                           std::vector<std::pair<double, double> >& isotopeMasses, //[out]
                           double charge = 1.);
 

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DIAPrescoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DIAPrescoring.h
@@ -44,6 +44,7 @@
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/TransitionExperiment.h>
 
 #include <OpenMS/DATASTRUCTURES/DefaultParamHandler.h>
+#include <OpenMS/ANALYSIS/OPENSWATH/DIAScoring.h>
 
 namespace OpenMS
 {
@@ -84,7 +85,8 @@ public:
       and compute manhattan distance and dotprod score between spectrum intensities
       and simulated spectrum.
     */
-    void score(OpenSwath::SpectrumPtr spec,
+    void score(IsotopeDistributionCache& iso,
+               OpenSwath::SpectrumPtr spec,
                const std::vector<OpenSwath::LightTransition>& lt,
                double& dotprod,
                double& manhattan);
@@ -93,7 +95,8 @@ public:
       @brief Compute manhattan and dotprod score for all spectra which can be accessed by
       the SpectrumAccessPtr for all transitions groups in the LightTargetedExperiment.
     */
-    void operator()(OpenSwath::SpectrumAccessPtr swath_ptr,
+    void operator()(IsotopeDistributionCache& iso,
+                    OpenSwath::SpectrumAccessPtr swath_ptr,
                     OpenSwath::LightTargetedExperiment& transition_exp_used,
                     OpenSwath::IDataFrameWriter* ivw);
   };

--- a/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DIAScoring.h
+++ b/src/openms/include/OpenMS/ANALYSIS/OPENSWATH/DIAScoring.h
@@ -42,6 +42,7 @@
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/DataStructures.h>
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/ITransition.h>
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/TransitionExperiment.h>
+#include <OpenMS/FILTERING/DATAREDUCTION/IsotopeDistributionCache.h>
 
 namespace OpenMS
 {
@@ -148,7 +149,10 @@ public:
                              double& manhattan);
     //@}
 
-private:
+    //function to access private member iso_cache_
+    IsotopeDistributionCache& getCache();
+
+  private:
 
     /// Copy constructor (algorithm class)
     DIAScoring(const DIAScoring& rhs);
@@ -214,6 +218,8 @@ private:
     double peak_before_mono_max_ppm_diff_;
     bool dia_extraction_ppm_;
     bool dia_centroided_;
+
+    IsotopeDistributionCache iso_cache_;
 
     TheoreticalSpectrumGenerator * generator;
   };

--- a/src/openms/include/OpenMS/FILTERING/DATAREDUCTION/IsotopeDistributionCache.h
+++ b/src/openms/include/OpenMS/FILTERING/DATAREDUCTION/IsotopeDistributionCache.h
@@ -36,6 +36,7 @@
 
 #include <OpenMS/KERNEL/StandardTypes.h>
 #include <OpenMS/TRANSFORMATIONS/FEATUREFINDER/FeatureFinderAlgorithmPickedHelperStructs.h>
+#include <OpenMS/CHEMISTRY/ISOTOPEDISTRIBUTION/IsotopeDistribution.h>
 
 namespace OpenMS
 {
@@ -47,16 +48,37 @@ namespace OpenMS
 public:
     typedef FeatureFinderAlgorithmPickedHelperStructs::TheoreticalIsotopePattern TheoreticalIsotopePattern;
 
-    IsotopeDistributionCache(double max_mass, double mass_window_width, double intensity_percentage = 0, double intensity_percentage_optional = 0);
+    /// @name Constructors and Destructors
+    //@{
+    /** Default constructor
+     */
+    IsotopeDistributionCache();
+
+    /// Destructor
+    ~IsotopeDistributionCache() = default;
+    //@}
+
+
+    void precalculateDistributionCache(Size num_begin, Size index);
+
+    void renormalize( TheoreticalIsotopePattern& isotopes, IsotopeDistribution& isotope_dist);
 
     /// Returns the isotope distribution for a certain mass window
-    const TheoreticalIsotopePattern & getIsotopeDistribution(double mass) const;
+    const TheoreticalIsotopePattern& getIsotopeDistribution(double mass) ;
+
+    const IsotopeDistribution& getIntensity(double mass);
 
 private:
     /// Vector of pre-calculated isotope distributions for several mass windows
     std::vector<TheoreticalIsotopePattern> isotope_distributions_;
 
+    std::vector<IsotopeDistribution> distribution_cache_;
+
     double mass_window_width_;
+
+    double intensity_percentage_ ;
+
+    double intensity_percentage_optional_;
   };
-}
+}//namespace OpenMS
 

--- a/src/openms/source/ANALYSIS/OPENSWATH/DIAPrescoring.cpp
+++ b/src/openms/source/ANALYSIS/OPENSWATH/DIAPrescoring.cpp
@@ -72,7 +72,8 @@ namespace OpenMS
     }
   }
 
-  void DiaPrescore::operator()(OpenSwath::SpectrumAccessPtr swath_ptr,
+  void DiaPrescore::operator()(IsotopeDistributionCache& iso,
+                               OpenSwath::SpectrumAccessPtr swath_ptr,
                                OpenSwath::LightTargetedExperiment& transition_exp_used,
                                OpenSwath::IDataFrameWriter* ivw)
   {
@@ -114,7 +115,7 @@ namespace OpenMS
         double score1;
         double score2;
         //OpenSwath::LightPeptide pep;
-        score(spec, beg->second, score1, score2);
+        score(iso, spec, beg->second, score1, score2);
 
         score1v.push_back(score1);
         score2v.push_back(score2);
@@ -127,7 +128,8 @@ namespace OpenMS
     } //end of forloop over spectra
   }
 
-  void DiaPrescore::score(OpenSwath::SpectrumPtr spec,
+  void DiaPrescore::score(IsotopeDistributionCache& iso,
+                          OpenSwath::SpectrumPtr spec,
                           const std::vector<OpenSwath::LightTransition>& lt,
                           double& dotprod,
                           double& manhattan)
@@ -137,7 +139,7 @@ namespace OpenMS
     std::vector<double> firstIstotope, theomasses;
     DIAHelpers::extractFirst(res, firstIstotope);
     std::vector<std::pair<double, double> > spectrum, spectrum2;
-    DIAHelpers::addIsotopes2Spec(res, spectrum, nr_charges_);
+    DIAHelpers::addIsotopes2Spec(iso, res, spectrum, nr_charges_);
     spectrum2.resize(spectrum.size());
     std::copy(spectrum.begin(), spectrum.end(), spectrum2.begin());
     //std::cout << spectrum.size() << std::endl;

--- a/src/tests/class_tests/openms/source/DIAPrescoring_test.cpp
+++ b/src/tests/class_tests/openms/source/DIAPrescoring_test.cpp
@@ -123,7 +123,8 @@ START_SECTION ( testscorefunction)
 
   DiaPrescore diaprescore(0.05);
   double manhattan = 0., dotprod = 0.;
-  diaprescore.score(sptr, transitions , dotprod, manhattan);
+  IsotopeDistributionCache isotope_cache;
+  diaprescore.score(isotope_cache, sptr, transitions , dotprod, manhattan);
   //std::cout << "dotprod : " << dotprod << std::endl;
   //std::cout << "manhattan : " << manhattan << std::endl;
   // >> exp = [240, 74, 39, 15, 0]

--- a/src/tests/class_tests/openms/source/IsotopeDistributionCache_test.cpp
+++ b/src/tests/class_tests/openms/source/IsotopeDistributionCache_test.cpp
@@ -41,12 +41,12 @@ using namespace OpenMS;
 
 START_TEST(IsotopeDistributionCache, "$Id$")
 
-START_SECTION(IsotopeDistributionCache(double max_mass, double mass_window_width, double intensity_percentage=0, double intensity_percentage_optional=0))
-  IsotopeDistributionCache c(100, 1);
+START_SECTION(IsotopeDistributionCache())
+  IsotopeDistributionCache c;
 END_SECTION 
 
 START_SECTION(const TheoreticalIsotopePattern& getIsotopeDistribution(double mass) const)
-  IsotopeDistributionCache c(1000, 10);
+  IsotopeDistributionCache c;
   const IsotopeDistributionCache::TheoreticalIsotopePattern &p(c.getIsotopeDistribution(500));
   TEST_REAL_SIMILAR(p.intensity[0], 1);
   TEST_REAL_SIMILAR(p.intensity[1], 0.267834);

--- a/src/utils/OpenSwathDIAPreScoring.cpp
+++ b/src/utils/OpenSwathDIAPreScoring.cpp
@@ -48,6 +48,8 @@
 #include <OpenMS/ANALYSIS/OPENSWATH/OpenSwathHelper.h>
 #include <OpenMS/OPENSWATHALGO/DATAACCESS/DataFrameWriter.h>
 
+#include <OpenMS/ANALYSIS/OPENSWATH/DIAScoring.h>
+
 #include <OpenMS/SYSTEM/File.h>
 #include <OpenMS/FORMAT/MzMLFile.h>
 
@@ -145,7 +147,8 @@ protected:
       std::cout << ltrans << std::endl;
     }
     // Here we deal with SWATH files (can be multiple files)
-
+    DIAScoring dia;
+    auto isotope_cache = dia.getCache();
     for (Size i = 0; i < file_list.size(); ++i)
     {
       MzMLFile swath_file;
@@ -201,7 +204,7 @@ protected:
       //std::cout << "using data frame writer for storing data. Outfile :" << out << std::endl;
       OpenSwath::IDataFrameWriter* dfw = new OpenSwath::CSVWriter(fname);
       OpenMS::DiaPrescore dp;
-      dp.operator()(spectrumAccess, transition_exp_used, dfw);
+      dp.operator()(isotope_cache, spectrumAccess, transition_exp_used, dfw);
       delete dfw;
       //featureFinder.pickExperiment(chromatogram_ptr, out_featureFile,
       //transition_exp_used, trafo, swath_ptr, transition_group_map);


### PR DESCRIPTION
# Implementation of Isotope Distribution Cache in OpenSWATHWorkflow
We noticed that in this workflow where in DIAScoring and DIAHelper we compute isotope Distributions, a huge part of the runtime is lost in the calculation `estimateFromPeptideWeight()`. (see the two "towers" in the flame graph below)
![dia_before](https://user-images.githubusercontent.com/62887073/83110597-9a89a400-a0c3-11ea-9a5f-3db8901896c0.jpg)

In order to avoid doing this calculation so often, we implemented a Cache which we save as a member in each DIAScoring and DIAHelper. For this implementation, we used `IsotopeDistributionCache.cpp` and `IsotopeDistributionCache.h`. The needed feature was already implemented there, such that we just had to adapt the usage of this `isotope_distribution_` member in each file and the corresponding calling functions. 
This change in the workflow led to a good improvement in runtime. 

# Benchmarks 
Without caching:
`OpenSwathWorkflow took 15:38 m (CPU)`
With IsotopDistributionCache: 
`OpenSwathWorkflow took 13:59 m (CPU)`