### PR TITLE
Feat/cwl add output directory

### DIFF
--- a/src/openms/source/FORMAT/ParamCWLFile.cpp
+++ b/src/openms/source/FORMAT/ParamCWLFile.cpp
@@ -122,6 +122,11 @@ namespace OpenMS
           tags.insert("output");
           tags.insert("prefixed");
         }
+        else if (t == TOPPBase::TAG_OUTPUT_DIR)
+        {
+          tags.insert("directory");
+          tags.insert("output");
+        }
         else
         {
           tags.insert(t);

--- a/src/openms/source/FORMAT/ParamCWLFile.cpp
+++ b/src/openms/source/FORMAT/ParamCWLFile.cpp
@@ -5,6 +5,7 @@
 // $Authors: Simon Gene Gottlieb $
 // --------------------------------------------------------------------------
 
+#include <OpenMS/APPLICATIONS/TOPPBase.h>
 #include <OpenMS/CONCEPT/LogStream.h>
 #include <OpenMS/FORMAT/ParamCWLFile.h>
 #include <fstream>
@@ -107,16 +108,16 @@ namespace OpenMS
       std::set<std::string> tags;
       for (auto const& t : param_it->tags)
       {
-        if (t == "input file")
+        if (t == TOPPBase::TAG_INPUT_FILE)
         {
           tags.insert("file");
         }
-        else if (t == "output file")
+        else if (t == TOPPBase::TAG_OUTPUT_FILE)
         {
           tags.insert("file");
           tags.insert("output");
         }
-        else if (t == "output prefix")
+        else if (t == TOPPBase::TAG_OUTPUT_PREFIX)
         {
           tags.insert("output");
           tags.insert("prefixed");

--- a/src/openms/source/FORMAT/ParamCWLFile.cpp
+++ b/src/openms/source/FORMAT/ParamCWLFile.cpp
@@ -103,7 +103,7 @@ namespace OpenMS
         }
       }
 
-      // converting trags to tdl compatible tags
+      // converting OpenMS tags to tdl compatible tags
       std::set<std::string> tags;
       for (auto const& t : param_it->tags)
       {


### PR DESCRIPTION
- ParamCWLFile is using the new introduced `TOPPBase::TAG_*` tags.
- ParamCWLFile is supporting the new `TOPPBase::TOP_OUTPUT_DIR` tag
- fixes a spelling mistake

Example Output of QualityControl.cwl:
```
[...]
inputs:
[...]
  out_txt__directory:
    doc: If a Path is given, '.txt' files compatible with MaxQuant will be created in this directory. If the directory does not exist, it will be created.
outputs:
  out:
    type: File?
    outputBinding:
      glob: $(inputs.out)
  out_cm:
    type: File?
    outputBinding:
      glob: $(inputs.out_cm)
  out_txt__directory:
    type: Directory?
    outputBinding:
      glob: $(inputs.out_txt__directory)
[...]
```
